### PR TITLE
Updated for embedded-hal v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ git = "https://github.com/japaric/owning-slice"
 
 [dependencies.smoltcp]
 default-features = false
-features = ["proto-ipv4", "socket-tcp"]
-version = "0.5.0"
+features = ["proto-ipv4", "socket-tcp", "ethernet"]
+version = "0.6.0"
 optional = true
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -6,11 +6,23 @@
 
 ## [API documentation](https://docs.rs/enc28j60)
 
-## Examples
+## Example
 
-You should find some examples in the [`stm32f103xx-hal`] crate.
+Example program on a STM32F1xx (bluepill) using a ST-Link V2.  
+See the [Rust Embedded Book](https://docs.rust-embedded.org/book/intro/install.html) or [STM32F1xx-hal](https://github.com/stm32-rs/stm32f1xx-hal) for setup details.
 
-[`stm32f103xx-hal`]: https://github.com/japaric/stm32f103xx-hal/tree/master/examples
+Attach OpenOCD to dongle:
+
+```sh
+openocd -f interface\stlink.cfg -f target\stm32f1x.cfg
+```
+
+Flash and Run:
+```sh
+cargo run --features=smoltcp --example smoltcp
+```
+
+Ping or navigate a web-browser to the IP address in `examples/smoltcp.rs`.
 
 ## License
 

--- a/src/bank0.rs
+++ b/src/bank0.rs
@@ -63,7 +63,7 @@ impl Register {
 }
 
 impl Into<crate::Register> for Register {
-    fn into(self) ->crate ::Register {
+    fn into(self) -> crate::Register {
         crate::Register::Bank0(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use byteorder::{ByteOrder, LE};
 use cast::usize;
 use embedded_hal::{
     blocking::{self, delay::DelayMs},
-    digital::{InputPin, OutputPin},
+    digital::v2::{InputPin, OutputPin},
     spi::{Mode, Phase, Polarity},
 };
 use owning_slice::IntoSliceTo;
@@ -330,8 +330,13 @@ where
 
             // status vector
             let status = RxStatus(LE::read_u32(&temp_buf[2..]));
-            let len = status.byte_count() as u16 - CRC_SZ;
+            let byte_count = status.byte_count() as u16;
 
+            if byte_count < CRC_SZ {
+                return Err(Error::CorruptRxBuffer);
+            }
+
+            let len = byte_count - CRC_SZ;
             if len > self.rxnd {
                 return Err(Error::CorruptRxBuffer);
             }
@@ -475,10 +480,10 @@ where
     fn _read_control_register(&mut self, register: Register) -> Result<u8, E> {
         self.change_bank(register)?;
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         let mut buffer = [Instruction::RCR.opcode() | register.addr(), 0];
         self.spi.transfer(&mut buffer)?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(buffer[1])
     }
@@ -506,10 +511,10 @@ where
     fn _write_control_register(&mut self, register: Register, value: u8) -> Result<(), E> {
         self.change_bank(register)?;
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         let buffer = [Instruction::WCR.opcode() | register.addr(), value];
         self.spi.write(&buffer)?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(())
     }
@@ -593,10 +598,10 @@ where
 
         self.change_bank(register)?;
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         self.spi
             .write(&[Instruction::BFC.opcode() | register.addr(), mask])?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(())
     }
@@ -613,10 +618,10 @@ where
 
         self.change_bank(register)?;
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         self.spi
             .write(&[Instruction::BFS.opcode() | register.addr(), mask])?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(())
     }
@@ -627,18 +632,18 @@ where
             self.write_control_register(bank0::Register::ERDPTH, addr.high())?;
         }
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         self.spi.write(&[Instruction::RBM.opcode()])?;
         self.spi.transfer(buf)?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(())
     }
 
     fn soft_reset(&mut self) -> Result<(), E> {
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         self.spi.transfer(&mut [Instruction::SRC.opcode()])?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
 
         Ok(())
     }
@@ -649,10 +654,10 @@ where
             self.write_control_register(bank0::Register::EWRPTH, addr.high())?;
         }
 
-        self.ncs.set_low();
+        let _ = self.ncs.set_low();
         self.spi.write(&[Instruction::WBM.opcode()])?;
         self.spi.write(buffer)?;
-        self.ncs.set_high();
+        let _ = self.ncs.set_high();
         Ok(())
     }
 }
@@ -683,7 +688,10 @@ where
 
     /// Checks if there's any interrupt pending to be processed by polling the INT pin
     pub fn interrupt_pending(&mut self) -> bool {
-        self.int.is_low()
+        match self.int.is_low() {
+            Ok(_) => true,
+            _ => false,
+        }
     }
 
     /// Stops listening for the specified event
@@ -768,8 +776,8 @@ where
     OP: OutputPin + 'static,
 {
     fn reset(&mut self) {
-        self.set_low();
-        self.set_high();
+        let _ = self.set_low();
+        let _ = self.set_high();
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -56,13 +56,13 @@ impl U16Ext for u16 {
     }
 
     fn be_repr(self) -> [u8; 2] {
-        let mut bytes: [u8; 2] = unsafe { mem::uninitialized() };
+        let mut bytes: [u8; 2] = unsafe { mem::MaybeUninit::uninit().assume_init() };
         BE::write_u16(&mut bytes, self);
         bytes
     }
 
     fn le_repr(self) -> [u8; 2] {
-        let mut bytes: [u8; 2] = unsafe { mem::uninitialized() };
+        let mut bytes: [u8; 2] = unsafe { mem::MaybeUninit::uninit().assume_init() };
         LE::write_u16(&mut bytes, self);
         bytes
     }


### PR DESCRIPTION
Example tested working with/without OpenOCD and `cargo run`.

Currently if partial http request packets are in the phy before the MCU starts up, or if a browser refresh request is sent then immediately stopped, then future http requests will not be served.
This has no effect on ping response handling.